### PR TITLE
Validate both copy and copyMove allowed effects in DragEnter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    katalyst-content (2.1.2)
+    katalyst-content (2.1.3)
       active_storage_validations
       katalyst-html-attributes
       katalyst-kpop

--- a/app/assets/stylesheets/katalyst/content/editor/_item-actions.scss
+++ b/app/assets/stylesheets/katalyst/content/editor/_item-actions.scss
@@ -39,6 +39,7 @@
 
     &::before {
       @extend %icon;
+      position: static;
       color: white;
       font-size: 1.125rem;
       line-height: 1.125rem;

--- a/app/assets/stylesheets/katalyst/content/editor/_new-items.scss
+++ b/app/assets/stylesheets/katalyst/content/editor/_new-items.scss
@@ -22,7 +22,7 @@
       font-size: 0.8rem;
       overflow: hidden;
       text-overflow: ellipsis;
-      margin-bottom: 0;
+      margin: 0 auto;
     }
 
     &:hover {

--- a/app/components/katalyst/content/editor/table_component.rb
+++ b/app/components/katalyst/content/editor/table_component.rb
@@ -11,6 +11,7 @@ module Katalyst
           dragleave->#{LIST_CONTROLLER}#dragleave
           drop->#{LIST_CONTROLLER}#drop
           dragend->#{LIST_CONTROLLER}#dragend
+          keyup.esc@document->#{LIST_CONTROLLER}#dragend
         ACTIONS
 
         renders_many :items, ->(item) do

--- a/app/javascript/content/editor/list_controller.js
+++ b/app/javascript/content/editor/list_controller.js
@@ -1,6 +1,19 @@
-import { Controller } from "@hotwired/stimulus";
+import {Controller} from "@hotwired/stimulus";
 
 export default class ListController extends Controller {
+  connect() {
+    this.enterCount = 0;
+  }
+
+  /**
+   * When the user starts a drag within the list, set the item's dataTransfer
+   * properties to indicate that it's being dragged and update its style.
+   *
+   * We delay setting the dataset property until the next animation frame
+   * so that the style updates can be computed before the drag begins.
+   *
+   * @param event {DragEvent}
+   */
   dragstart(event) {
     if (this.element !== event.target.parentElement) return;
 
@@ -8,51 +21,86 @@ export default class ListController extends Controller {
     event.dataTransfer.effectAllowed = "move";
 
     // update element style after drag has begun
-    setTimeout(() => (target.dataset.dragging = ""));
+    requestAnimationFrame(() => (target.dataset.dragging = ""));
   }
 
+  /**
+   * When the user drags an item over another item in the last, swap the
+   * dragging item with the item under the cursor.
+   *
+   * As a special case, if the item is dragged over placeholder space at the end
+   * of the list, move the item to the bottom of the list instead. This allows
+   * users to hit the list element more easily when adding new items to an empty
+   * list.
+   *
+   * @param event {DragEvent}
+   */
   dragover(event) {
-    const item = this.dragItem();
+    const item = this.dragItem;
     if (!item) return;
 
-    swap(this.dropTarget(event.target), item);
+    swap(dropTarget(event.target), item);
 
     event.preventDefault();
     return true;
   }
 
+  /**
+   * When the user drags an item into the list, create a placeholder item to
+   * represent the new item. Note that we can't access the drag data
+   * until drop, so we assume that this is our template item for now.
+   *
+   * Users can cancel the drag by dragging the item out of the list or by
+   * pressing escape. Both are handled by `cancelDrag`.
+   *
+   * @param event {DragEvent}
+   */
   dragenter(event) {
     event.preventDefault();
 
-    if (event.dataTransfer.effectAllowed === "copy" && !this.dragItem()) {
+    // Safari doesn't support relatedTarget, so we count enter/leave pairs
+    this.enterCount++;
+
+    if (copyAllowed(event) && !this.dragItem) {
       const item = document.createElement("li");
       item.dataset.dragging = "";
       item.dataset.newItem = "";
-      this.element.prepend(item);
+      this.element.appendChild(item);
     }
   }
 
+  /**
+   * When the user drags the item out of the list, remove the placeholder.
+   * This allows users to cancel the drag by dragging the item out of the list.
+   *
+   * @param event {DragEvent}
+   */
   dragleave(event) {
-    const item = this.dragItem();
-    const related = this.dropTarget(event.relatedTarget);
+    // Safari doesn't support relatedTarget, so we count enter/leave pairs
+    // https://bugs.webkit.org/show_bug.cgi?id=66547
+    this.enterCount--;
 
-    // ignore if item is not set or we're moving into a valid drop target
-    if (!item || related) return;
-
-    // remove item if it's a new item
-    if (item.dataset.hasOwnProperty("newItem")) {
-      item.remove();
+    if (this.enterCount <= 0 && this.dragItem.dataset.hasOwnProperty("newItem")) {
+      this.cancelDrag(event);
     }
   }
 
+  /**
+   * When the user drops an item into the list, end the drag and reindex the list.
+   *
+   * If the item is a new item, we replace the placeholder with the template
+   * item data from the dataTransfer API.
+   *
+   * @param event {DragEvent}
+   */
   drop(event) {
-    let item = this.dragItem();
+    let item = this.dragItem;
 
     if (!item) return;
 
     event.preventDefault();
     delete item.dataset.dragging;
-    swap(this.dropTarget(event.target), item);
+    swap(dropTarget(event.target), item);
 
     if (item.dataset.hasOwnProperty("newItem")) {
       const placeholder = item;
@@ -61,42 +109,53 @@ export default class ListController extends Controller {
       item = template.content.querySelector("li");
 
       this.element.replaceChild(item, placeholder);
-      setTimeout(() =>
+      requestAnimationFrame(() =>
         item.querySelector("[role='button'][value='edit']").click()
       );
     }
 
-    this.dispatch("drop", { target: item, bubbles: true, prefix: "content" });
+    this.dispatch("drop", {target: item, bubbles: true, prefix: "content"});
   }
 
+  /**
+   * End an in-progress drag. If the item is a new item, remove it, otherwise
+   * reset the item's style and restore its original position in the list.
+   */
   dragend() {
-    const item = this.dragItem();
-    if (!item) return;
+    const item = this.dragItem;
 
-    delete item.dataset.dragging;
-    this.reset();
+    if (!item) {
+    } else if (item.dataset.hasOwnProperty("newItem")) {
+      item.remove();
+    } else {
+      delete item.dataset.dragging;
+      this.reset();
+    }
   }
 
-  dragItem() {
+  get isDragging() {
+    return !!this.dragItem;
+  }
+
+  get dragItem() {
     return this.element.querySelector("[data-dragging]");
   }
 
-  dropTarget(e) {
-    return (
-      e.closest("[data-controller='content--editor--list'] > *") ||
-      e.closest("[data-controller='content--editor--list']")
-    );
-  }
-
   reindex() {
-    this.dispatch("reindex", { bubbles: true, prefix: "content" });
+    this.dispatch("reindex", {bubbles: true, prefix: "content"});
   }
 
   reset() {
-    this.dispatch("reset", { bubbles: true, prefix: "content" });
+    this.dispatch("reset", {bubbles: true, prefix: "content"});
   }
 }
 
+/**
+ * Swaps two list items. If target is a list, the item is appended.
+ *
+ * @param target the target element to swap with
+ * @param item the item the user is dragging
+ */
 function swap(target, item) {
   if (!target) return;
   if (target === item) return;
@@ -113,4 +172,26 @@ function swap(target, item) {
   if (target.nodeName === "OL") {
     target.appendChild(item);
   }
+}
+
+/**
+ * Returns true if the event supports copy or copy move.
+ *
+ * Chrome and Firefox use copy, but Safari only supports copyMove.
+ */
+function copyAllowed(event) {
+  return (
+    event.dataTransfer.effectAllowed === "copy" ||
+    event.dataTransfer.effectAllowed === "copyMove"
+  );
+}
+
+/**
+ * Given an event target, return the closest drop target, if any.
+ */
+function dropTarget(e) {
+  return e && (
+    e.closest("[data-controller='content--editor--list'] > *") ||
+    e.closest("[data-controller='content--editor--list']")
+  );
 }

--- a/bin/setup
+++ b/bin/setup
@@ -4,5 +4,6 @@ IFS=$'\n\t'
 set -vx
 
 bundle install
+yarn install
 
-# Do any other automated setup that you need to do here
+spec/dummy/bin/setup

--- a/katalyst-content.gemspec
+++ b/katalyst-content.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name    = "katalyst-content"
-  spec.version = "2.1.2"
+  spec.version = "2.1.3"
   spec.authors = ["Katalyst Interactive"]
   spec.email   = ["developers@katalyst.com.au"]
 


### PR DESCRIPTION
* Known issue on safari -> if user moves the drag item outside the drop-zone the item won't be removed as we do not get the relatedTarget of the drag events