### PR TITLE
Add an in-memory enum and scopes for status for table filtering

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,7 +178,7 @@ GEM
       katalyst-html-attributes
       turbo-rails
       view_component
-    katalyst-tables (3.4.3)
+    katalyst-tables (3.4.4)
       katalyst-html-attributes
       view_component
     language_server-protocol (3.17.0.3)

--- a/app/components/katalyst/content/editor/status_bar_component.rb
+++ b/app/components/katalyst/content/editor/status_bar_component.rb
@@ -25,7 +25,7 @@ module Katalyst
           status_text  = t("views.katalyst.content.editor.#{state}_html", **)
           html_options = { class: "status-text", data: { state => "", turbo: false } }
 
-          case state
+          case state.to_sym
           when :published
             link_to status_text, url_for(container), **html_options
           when :unpublished, :draft
@@ -38,7 +38,7 @@ module Katalyst
         def actions
           tag.menu do
             concat action(:discard, class: "button button--text")
-            concat action(:revert, class: "button button--text") if container.state == :draft
+            concat action(:revert, class: "button button--text") if container.draft?
             concat action(:save, class: "button button--secondary")
             concat action(:publish, class: "button button--primary")
           end

--- a/spec/dummy/app/assets/stylesheets/base/form/_index.scss
+++ b/spec/dummy/app/assets/stylesheets/base/form/_index.scss
@@ -18,6 +18,7 @@
   }
 
   input:not([type="submit"]):not([type="button"]),
+  &[data-controller=tables--query] .query-input .highlight,
   textarea {
     @include input;
   }

--- a/spec/dummy/app/controllers/admin/pages_controller.rb
+++ b/spec/dummy/app/controllers/admin/pages_controller.rb
@@ -88,7 +88,7 @@ module Admin
 
       attribute :title, :string
       attribute :slug, :string
-      attribute :content_text, :string
+      attribute :state, :enum, scope: :state
     end
   end
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Page do
                           .with_message(I18n.t("activerecord.errors.messages.missing_item"), against: :items)
   end
 
-  it { is_expected.to have_attributes(state: :published) }
+  it { is_expected.to have_attributes(state: "published") }
   it { expect(page.draft_version).to eq(page.published_version) }
 
   it "stores the expect json (id/depth but no index)" do
@@ -78,9 +78,40 @@ RSpec.describe Page do
     it { expect { update }.to change(page, :slug) }
   end
 
-  describe "#published?" do
-    it { expect(create(:page)).to be_published }
-    it { expect(create(:page, :unpublished)).not_to be_published }
+  context "when unpublished" do
+    let!(:page) { create(:page, :unpublished) }
+
+    it { expect(page).to have_attributes(state: "unpublished") }
+    it { expect(page).to be_unpublished }
+    it { expect(page).not_to be_published }
+    it { expect(page).not_to be_draft }
+    it { expect(described_class.unpublished).to contain_exactly(page) }
+    it { expect(described_class.published).not_to include(page) }
+    it { expect(described_class.draft).not_to include(page) }
+  end
+
+  context "when published" do
+    let!(:page) { create(:page, :published) }
+
+    it { expect(page).to have_attributes(state: "published") }
+    it { expect(page).not_to be_unpublished }
+    it { expect(page).to be_published }
+    it { expect(page).not_to be_draft }
+    it { expect(described_class.unpublished).not_to include(page) }
+    it { expect(described_class.published).to contain_exactly(page) }
+    it { expect(described_class.draft).not_to include(page) }
+  end
+
+  context "when draft" do
+    let!(:page) { create(:page, :draft) }
+
+    it { expect(page).to have_attributes(state: "draft") }
+    it { expect(page).not_to be_unpublished }
+    it { expect(page).to be_published }
+    it { expect(page).to be_draft }
+    it { expect(described_class.unpublished).not_to include(page) }
+    it { expect(described_class.published).not_to include(page) }
+    it { expect(described_class.draft).to contain_exactly(page) }
   end
 
   describe ".versions.active" do
@@ -110,7 +141,7 @@ RSpec.describe Page do
 
   shared_examples "a versioned change" do
     it "changes state" do
-      expect { update }.to change(page, :state).from(:published).to(:draft)
+      expect { update }.to change(page, :state).from("published").to("draft")
     end
 
     it "creates a new version" do


### PR DESCRIPTION
Note: this changes state values from symbols to strings.