### PR TITLE
Fix: Add support to load overridden partial files

### DIFF
--- a/app/components/katalyst/content/editor/item_editor_component.rb
+++ b/app/components/katalyst/content/editor/item_editor_component.rb
@@ -8,6 +8,16 @@ module Katalyst
 
         alias_method :model, :item
 
+        module Helpers
+          def prefix_partial_path_with_controller_namespace
+            false
+          end
+        end
+
+        def before_render
+          helpers.extend(Helpers)
+        end
+
         def call
           render("form", model:, scope:, url:, id:)
         end


### PR DESCRIPTION
* This fix is required to load the correct partial file in scenarios where a content model is overridden

This code block was removed(I believe incorrectly) on upgrade to 3.0.0